### PR TITLE
Only send confirmation mail if order status is paid

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Also, you need to define a mapping from the four possible [Mollie responses](htt
 ```python
 # settings.py
 MOLLIE_STATUS_MAPPING = {
-    'Paid': 'Being processed',
+    'Paid': ORDER_STATUS_PAID,
     'Pending': 'Pending Payment',
     'Open': 'Pending Payment',
     'Cancelled': 'Cancelled'

--- a/mollie_oscar/views.py
+++ b/mollie_oscar/views.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.urlresolvers import NoReverseMatch, reverse
 from django.db import transaction
@@ -54,6 +55,12 @@ class WebhookView(OrderPlacementMixin, View):
 
             # Send Message now since this was blocked before
             order = facade.get_order(payment_id)
-            self.send_confirmation_message(order, self.communication_type_code)
+
+            # Only send confirmation if order is paid
+            if order.status in settings.OSCAR_MOLLIE_CONFIRMED_STATUSES:
+                self.send_confirmation_message(
+                    order,
+                    self.communication_type_code,
+                )
 
         return HttpResponse(status=200)

--- a/sandbox/settings.py
+++ b/sandbox/settings.py
@@ -1,18 +1,21 @@
 from settings import *
 
 
+ORDER_STATUS_PAID = 'Being processed'
+
 # Oscar Shop settings
 OSCAR_INITIAL_ORDER_STATUS = OSCAR_INITIAL_LINE_STATUS = 'Pending Payment'
 OSCAR_ORDER_STATUS_PIPELINE = {
-    'Pending Payment': ('Being processed', 'Cancelled',),
-    'Being processed': ('Being processed', 'Cancelled',),
+    'Pending Payment': (ORDER_STATUS_PAID, 'Cancelled',),
+    ORDER_STATUS_PAID: (ORDER_STATUS_PAID, 'Cancelled',),
     'Cancelled': (),
 }
+OSCAR_MOLLIE_CONFIRMED_STATUSES = [ORDER_STATUS_PAID]
 
 # Mollie settings
 MOLLIE_API_KEY = 'secret-key-123'
 MOLLIE_STATUS_MAPPING = {
-    'Paid': 'Being processed',
+    'Paid': ORDER_STATUS_PAID,
     'Pending': 'Pending Payment',
     'Open': 'Pending Payment',
     'Cancelled': 'Cancelled'


### PR DESCRIPTION
If Mollie would return 'cancelled', then mollie_oscar would cancel the order (as defined in MOLLIE_STATUS_MAPPING). However, a confirmation mail would still be sent. 

I'm not sure if this is due to me not understanding how mollie_oscar should work. But this patch does fix it. Or maybe i do not understand correctly how it should work, i'm open to suggestions. Thanks!