### PR TITLE
Make protocol of redirect urls configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ You need to make sure your webhook URI is accessible. To do so, include the foll
 url(r'^mollie/', include('mollie_oscar.urls', namespace='mollie_oscar')),
 ```
 
+## HTTPS ##
+
+If your site runs on HTTPS, turn this on by enabling the following setting:
+```python
+OSCAR_MOLLIE_HTTPS = True
+```
+
 ## Examples ##
 
 Please visit the [sandbox](https://github.com/JorrandeWit/django-oscar-mollie/tree/master/sandbox) to see how to integrate Mollie into your Oscar application.

--- a/mollie_oscar/facade.py
+++ b/mollie_oscar/facade.py
@@ -49,7 +49,8 @@ class Facade(object):
             redirect_url = reverse('customer:order', kwargs={'order_number': order_number})
 
         site = Site.objects.get_current()
-        redirect_url = 'http://%s%s' % (site.domain, redirect_url)
+        protocol = 'https' if settings.OSCAR_MOLLIE_HTTPS else 'http'
+        redirect_url = '%s://%s%s' % (protocol, site.domain, redirect_url)
 
         payment = self.mollie.payments.create({
             'amount': float(total),
@@ -76,7 +77,8 @@ class Facade(object):
     def get_webhook_url(self):
         # TODO: Make this related to this app without explicit namespace declaration...?
         site = Site.objects.get_current()
-        return 'http://%s%s' % (site.domain, reverse('mollie_oscar:webhook'))
+        protocol = 'https' if settings.OSCAR_MOLLIE_HTTPS else 'http'
+        return '%s://%s%s' % (protocol, site.domain, reverse('mollie_oscar:webhook'))
 
     def get_order(self, payment_id, order_nr=None):
         _lazy_get_models()

--- a/mollie_oscar/views.py
+++ b/mollie_oscar/views.py
@@ -42,7 +42,8 @@ class WebhookView(OrderPlacementMixin, View):
                 pass
             else:
                 site = Site.objects.get_current()
-                ctx['status_url'] = 'http://%s%s' % (site.domain, path)
+                protocol = 'https' if settings.OSCAR_MOLLIE_HTTPS else 'http'
+                ctx['status_url'] = '%s://%s%s' % (protocol, site.domain, path)
         else:
             ctx['status_url'] = None
         return ctx


### PR DESCRIPTION
I noticed that all redirects from Mollie went to `http`, so I've made the protocol of the webhook url and redirect url configurable through a setting. 

