### PR TITLE
Upgrade supported mollie client

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(name='django-oscar-mollie',
         'mollie_oscar'
       ],
       install_requires=[
-        'mollie-api-python<1.4',
+        'mollie-api-python>=2,<4',
         'django>=2.1',
         'django-oscar>=2.1',
       ]


### PR DESCRIPTION
Upgrade the used Mollie API client to the latest version

We ran into an issue for a legacy project that uses this integration. The `v1.x.x` client will no longer perform correct GET queries to the API, because of an ugly bug. This has been fixed in newer versions of the client.

Furthermore, the v1.x.x client uses the v1 API at Mollie, [which is deprecated and might be disabled after July this year](https://docs.mollie.com/reference/v1/payments-api/create-payment)